### PR TITLE
fix(helmfile): add missing values-staging.yaml for staging environment

### DIFF
--- a/helm/betamis-infra/values-staging.yaml
+++ b/helm/betamis-infra/values-staging.yaml
@@ -1,0 +1,6 @@
+postgres:
+  auth:
+    password: betamis_secret
+
+kafka:
+  advertisedHost: kafka.betamis-infra.svc.cluster.local

--- a/helm/cert-issuer/values-staging.yaml
+++ b/helm/cert-issuer/values-staging.yaml
@@ -1,0 +1,3 @@
+issuer:
+  name: betamis-selfsigned
+  type: selfsigned

--- a/helm/ingress-nginx/values-staging.yaml
+++ b/helm/ingress-nginx/values-staging.yaml
@@ -1,0 +1,16 @@
+# kind-specific staging overrides — mirrors dev: single controller on the
+# control-plane node with hostPort so traffic on 80/443 reaches the pod.
+controller:
+  replicaCount: 1
+  hostPort:
+    enabled: true
+  nodeSelector:
+    ingress-ready: "true"
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+  service:
+    type: NodePort
+  admissionWebhooks:
+    enabled: false


### PR DESCRIPTION
## Summary

- Adds `helm/ingress-nginx/values-staging.yaml` — kind-compatible single-replica controller with hostPort and admission webhooks disabled, matching the dev profile
- Adds `helm/betamis-infra/values-staging.yaml` — local credentials matching dev
- Adds `helm/cert-issuer/values-staging.yaml` — selfsigned issuer for mkcert-backed TLS

Without these files `helmfile sync -e staging` fails because the helmfile template `values-{{ .Environment.Name }}.yaml` resolves to a non-existent path for ingress-nginx, betamis-infra, and cert-issuer.

The remote `staging` branch was also pushed so ArgoCD `targetRevision: staging` apps can sync.

## Test plan

- [ ] `helmfile lint -e staging` passes without missing-file errors
- [ ] `helmfile sync -e staging` deploys all releases to `betamis-staging`
- [ ] `https://staging.betamis.local/api/predictions` is reachable after setup
- [ ] ArgoCD staging apps (e.g. `prediction-service-staging`) show `Synced`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)