### PR TITLE
[S5] Prometheus & alerting

### DIFF
--- a/helm/betamis-infra/templates/grafana.yaml
+++ b/helm/betamis-infra/templates/grafana.yaml
@@ -16,9 +16,9 @@ data:
         isDefault: true
         jsonData:
           tracesToLogsV2:
-            datasourceUid: ""  # set to Loki UID when Loki is deployed
+            datasourceUid: ~  # set to Loki UID when Loki is deployed
           serviceMap:
-            datasourceUid: ""  # set to Prometheus UID when Prometheus is deployed
+            datasourceUid: ~  # set to Prometheus UID when Prometheus is deployed
           nodeGraph:
             enabled: true
 ---

--- a/helm/kube-prometheus-stack/values-dev.yaml
+++ b/helm/kube-prometheus-stack/values-dev.yaml
@@ -1,0 +1,11 @@
+# Reduced resource footprint for local kind clusters.
+prometheus:
+  prometheusSpec:
+    retention: 24h
+    resources:
+      requests:
+        memory: "200Mi"
+        cpu: "50m"
+      limits:
+        memory: "400Mi"
+        cpu: "200m"

--- a/helm/kube-prometheus-stack/values-prod.yaml
+++ b/helm/kube-prometheus-stack/values-prod.yaml
@@ -1,0 +1,10 @@
+prometheus:
+  prometheusSpec:
+    retention: 30d
+    resources:
+      requests:
+        memory: "1Gi"
+        cpu: "200m"
+      limits:
+        memory: "4Gi"
+        cpu: "1000m"

--- a/helm/kube-prometheus-stack/values-staging.yaml
+++ b/helm/kube-prometheus-stack/values-staging.yaml
@@ -1,0 +1,11 @@
+# Reduced resource footprint for kind-based staging clusters (mirrors dev).
+prometheus:
+  prometheusSpec:
+    retention: 24h
+    resources:
+      requests:
+        memory: "200Mi"
+        cpu: "50m"
+      limits:
+        memory: "400Mi"
+        cpu: "200m"

--- a/helm/kube-prometheus-stack/values.yaml
+++ b/helm/kube-prometheus-stack/values.yaml
@@ -1,0 +1,27 @@
+# kube-prometheus-stack base values.
+# Grafana is disabled — BetAmis already runs its own Grafana instance (betamis-infra chart).
+# Alertmanager is disabled — alerts are visible in the Prometheus UI; wire up a receiver when needed.
+
+grafana:
+  enabled: false
+
+alertmanager:
+  enabled: false
+
+# Allow Prometheus to discover ServiceMonitors and PrometheusRules in any namespace.
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelector: {}
+    serviceMonitorNamespaceSelector: {}
+    podMonitorSelector: {}
+    podMonitorNamespaceSelector: {}
+    ruleSelector: {}
+    ruleNamespaceSelector: {}
+    retention: 7d
+    resources:
+      requests:
+        memory: "400Mi"
+        cpu: "100m"
+      limits:
+        memory: "1Gi"
+        cpu: "500m"

--- a/helm/league-service/templates/service.yaml
+++ b/helm/league-service/templates/service.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     app: {{ .Chart.Name }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
   type: ClusterIP

--- a/helm/match-service/templates/service.yaml
+++ b/helm/match-service/templates/service.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     app: {{ .Chart.Name }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
   type: ClusterIP

--- a/helm/prediction-service/templates/service.yaml
+++ b/helm/prediction-service/templates/service.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     app: {{ .Chart.Name }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
   type: ClusterIP

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: prometheus
+description: BetAmis Prometheus ServiceMonitors and alerting rules
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/prometheus/templates/prometheusrule.yaml
+++ b/helm/prometheus/templates/prometheusrule.yaml
@@ -1,0 +1,44 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: betamis-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: betamis.alerts
+      rules:
+        - alert: BetamisServiceDown
+          expr: up{namespace=~"betamis-.*"} == 0
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "BetAmis service {{ "{{" }} $labels.job {{ "}}" }} is down"
+            description: "{{ "{{" }} $labels.job {{ "}}" }} has been unreachable for more than 2 minutes."
+
+        - alert: BetamisKafkaConsumerLagHigh
+          expr: kafka_consumer_fetch_manager_records_lag_max{group_id="scoring-service"} > 1000
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Kafka consumer lag too high on topic {{ "{{" }} $labels.topic {{ "}}" }}"
+            description: "scoring-service consumer lag on topic {{ "{{" }} $labels.topic {{ "}}" }} has exceeded 1000 messages for more than 5 minutes."
+
+        - alert: BetamisHttpErrorRateHigh
+          expr: |
+            (
+              rate(http_server_requests_seconds_count{status=~"5..",namespace=~"betamis-.*"}[5m])
+              /
+              rate(http_server_requests_seconds_count{namespace=~"betamis-.*"}[5m])
+            ) > 0.05
+            and
+            rate(http_server_requests_seconds_count{namespace=~"betamis-.*"}[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High HTTP 5xx error rate on {{ "{{" }} $labels.job {{ "}}" }}"
+            description: "{{ "{{" }} $labels.job {{ "}}" }} has a 5xx error rate above 5% for more than 5 minutes."

--- a/helm/prometheus/templates/servicemonitors.yaml
+++ b/helm/prometheus/templates/servicemonitors.yaml
@@ -1,0 +1,20 @@
+{{- $services := list "league-service" "match-service" "prediction-service" "scoring-service" }}
+{{- range $services }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ . }}
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: {{ . }}
+  endpoints:
+    - port: http
+      path: /q/metrics
+      interval: 30s
+{{- end }}

--- a/helm/prometheus/values-dev.yaml
+++ b/helm/prometheus/values-dev.yaml
@@ -1,0 +1,1 @@
+# No environment-specific overrides needed for dev.

--- a/helm/prometheus/values-prod.yaml
+++ b/helm/prometheus/values-prod.yaml
@@ -1,0 +1,1 @@
+# No environment-specific overrides needed for prod.

--- a/helm/prometheus/values-staging.yaml
+++ b/helm/prometheus/values-staging.yaml
@@ -1,0 +1,1 @@
+# No environment-specific overrides needed for staging.

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -1,0 +1,3 @@
+# Default values — overridden per environment.
+# kube-prometheus-stack is deployed as a separate helmfile release;
+# this chart only contains ServiceMonitors and PrometheusRule CRD instances.

--- a/helm/scoring-service/templates/service.yaml
+++ b/helm/scoring-service/templates/service.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     app: {{ .Chart.Name }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
   type: ClusterIP

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -3,6 +3,8 @@ repositories:
     url: https://kubernetes.github.io/ingress-nginx
   - name: jetstack
     url: https://charts.jetstack.io
+  - name: prometheus-community
+    url: https://prometheus-community.github.io/helm-charts
 
 environments:
   dev:
@@ -50,6 +52,27 @@ releases:
     values:
       - ./helm/cert-issuer/values.yaml
       - ./helm/cert-issuer/values-{{ .Environment.Name }}.yaml
+
+  # ── Monitoring ──────────────────────────────────────────────────────────────
+  - name: kube-prometheus-stack
+    namespace: monitoring
+    createNamespace: true
+    chart: prometheus-community/kube-prometheus-stack
+    version: "67.9.0"
+    values:
+      - ./helm/kube-prometheus-stack/values.yaml
+      - ./helm/kube-prometheus-stack/values-{{ .Environment.Name }}.yaml
+
+  # ServiceMonitors and PrometheusRule (CRD instances — needs Prometheus Operator)
+  - name: prometheus
+    namespace: {{ .Values.appNamespace }}
+    createNamespace: true
+    chart: ./helm/prometheus
+    needs:
+      - monitoring/kube-prometheus-stack
+    values:
+      - ./helm/prometheus/values.yaml
+      - ./helm/prometheus/values-{{ .Environment.Name }}.yaml
 
   # ── Infrastructure ──────────────────────────────────────────────────────────
   - name: betamis-infra

--- a/league-service/src/main/java/com/betamis/league/application/usecase/CreateLeagueUseCase.java
+++ b/league-service/src/main/java/com/betamis/league/application/usecase/CreateLeagueUseCase.java
@@ -5,6 +5,8 @@ import com.betamis.league.domain.model.League;
 import com.betamis.league.domain.port.in.CreateLeague;
 import com.betamis.league.domain.port.out.LeagueEventPublisher;
 import com.betamis.league.domain.port.out.LeagueRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -14,12 +16,15 @@ public class CreateLeagueUseCase implements CreateLeague {
 
     private final LeagueRepository leagueRepository;
     private final LeagueEventPublisher eventPublisher;
+    private final Counter leaguesCreatedCounter;
 
     @Inject
     public CreateLeagueUseCase(LeagueRepository leagueRepository,
-                               LeagueEventPublisher eventPublisher) {
+                               LeagueEventPublisher eventPublisher,
+                               MeterRegistry registry) {
         this.leagueRepository = leagueRepository;
         this.eventPublisher = eventPublisher;
+        this.leaguesCreatedCounter = registry.counter("betamis_leagues_created_total");
     }
 
     @Override
@@ -34,6 +39,7 @@ public class CreateLeagueUseCase implements CreateLeague {
             }
         });
 
+        leaguesCreatedCounter.increment();
         return league;
     }
 }

--- a/league-service/src/main/java/com/betamis/league/application/usecase/JoinLeagueUseCase.java
+++ b/league-service/src/main/java/com/betamis/league/application/usecase/JoinLeagueUseCase.java
@@ -6,6 +6,8 @@ import com.betamis.league.domain.model.League;
 import com.betamis.league.domain.port.in.JoinLeague;
 import com.betamis.league.domain.port.out.LeagueEventPublisher;
 import com.betamis.league.domain.port.out.LeagueRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -17,12 +19,15 @@ public class JoinLeagueUseCase implements JoinLeague {
 
     private final LeagueRepository leagueRepository;
     private final LeagueEventPublisher eventPublisher;
+    private final Counter leagueJoinsCounter;
 
     @Inject
     public JoinLeagueUseCase(LeagueRepository leagueRepository,
-                             LeagueEventPublisher eventPublisher) {
+                             LeagueEventPublisher eventPublisher,
+                             MeterRegistry registry) {
         this.leagueRepository = leagueRepository;
         this.eventPublisher = eventPublisher;
+        this.leagueJoinsCounter = registry.counter("betamis_league_joins_total");
     }
 
     @Override
@@ -40,6 +45,8 @@ public class JoinLeagueUseCase implements JoinLeague {
                 eventPublisher.publish(e);
             }
         });
+
+        leagueJoinsCounter.increment();
     }
 }
 

--- a/league-service/src/main/resources/application.properties
+++ b/league-service/src/main/resources/application.properties
@@ -36,6 +36,9 @@ mp.messaging.outgoing.league-member-joined.topic=league.member-joined
 mp.messaging.outgoing.league-member-joined.value.serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
 mp.messaging.outgoing.league-member-joined.schema.registry.url=${KAFKA_SCHEMA_REGISTRY_URL:http://localhost:8081}
 
+# ── Metrics (Prometheus) ──────────────────────────────────────────────────────
+quarkus.micrometer.export.prometheus.enabled=true
+
 # ── OpenTelemetry ─────────────────────────────────────────────────────────────
 quarkus.application.name=league-service
 quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}

--- a/league-service/src/test/java/com/betamis/league/application/usecase/CreateLeagueUseCaseTest.java
+++ b/league-service/src/test/java/com/betamis/league/application/usecase/CreateLeagueUseCaseTest.java
@@ -4,6 +4,7 @@ import com.betamis.league.domain.event.LeagueCreated;
 import com.betamis.league.domain.model.League;
 import com.betamis.league.domain.port.out.LeagueEventPublisher;
 import com.betamis.league.domain.port.out.LeagueRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,13 +17,15 @@ class CreateLeagueUseCaseTest {
 
     private LeagueRepository repository;
     private LeagueEventPublisher publisher;
+    private SimpleMeterRegistry registry;
     private CreateLeagueUseCase useCase;
 
     @BeforeEach
     void setUp() {
         repository = mock(LeagueRepository.class);
         publisher = mock(LeagueEventPublisher.class);
-        useCase = new CreateLeagueUseCase(repository, publisher);
+        registry = new SimpleMeterRegistry();
+        useCase = new CreateLeagueUseCase(repository, publisher, registry);
     }
 
     @Test
@@ -49,6 +52,18 @@ class CreateLeagueUseCaseTest {
         // Events are consumed during create(); pollDomainEvents() must return empty afterwards
         assertTrue(league.pollDomainEvents().isEmpty());
         verify(publisher, times(1)).publish(any(LeagueCreated.class));
+    }
+
+    @Test
+    @DisplayName("betamis_leagues_created_total is pre-registered at 0 and increments per successful create()")
+    void shouldIncrementLeaguesCreatedCounter() {
+        assertEquals(0.0, registry.counter("betamis_leagues_created_total").count());
+
+        useCase.create("League A", "user-1");
+        assertEquals(1.0, registry.counter("betamis_leagues_created_total").count());
+
+        useCase.create("League B", "user-2");
+        assertEquals(2.0, registry.counter("betamis_leagues_created_total").count());
     }
 }
 

--- a/league-service/src/test/java/com/betamis/league/application/usecase/JoinLeagueUseCaseTest.java
+++ b/league-service/src/test/java/com/betamis/league/application/usecase/JoinLeagueUseCaseTest.java
@@ -9,6 +9,7 @@ import com.betamis.league.domain.model.League;
 import com.betamis.league.domain.model.Membership;
 import com.betamis.league.domain.port.out.LeagueEventPublisher;
 import com.betamis.league.domain.port.out.LeagueRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,13 +26,15 @@ class JoinLeagueUseCaseTest {
 
     private LeagueRepository repository;
     private LeagueEventPublisher publisher;
+    private SimpleMeterRegistry registry;
     private JoinLeagueUseCase useCase;
 
     @BeforeEach
     void setUp() {
         repository = mock(LeagueRepository.class);
         publisher = mock(LeagueEventPublisher.class);
-        useCase = new JoinLeagueUseCase(repository, publisher);
+        registry = new SimpleMeterRegistry();
+        useCase = new JoinLeagueUseCase(repository, publisher, registry);
     }
 
     @Test
@@ -91,6 +94,27 @@ class JoinLeagueUseCaseTest {
                 () -> useCase.join("league-1", "user-1", inv.code()));
         verify(repository, never()).save(any());
         verify(publisher, never()).publish(any(MemberJoined.class));
+    }
+
+    @Test
+    @DisplayName("betamis_league_joins_total increments only on successful join, not on exceptions")
+    void shouldIncrementJoinsCounterOnlyOnSuccess() {
+        assertEquals(0.0, registry.counter("betamis_league_joins_total").count());
+
+        Invitation inv = Invitation.generate(Instant.now());
+        League league = League.reconstitute("league-1", "Test", "user-1",
+                List.of(new Membership("user-1", Instant.now())),
+                List.of(inv),
+                Instant.now());
+        when(repository.findById("league-1")).thenReturn(Optional.of(league));
+        when(repository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThrows(LeagueNotFoundException.class,
+                () -> useCase.join("missing", "user-2", "XXXXXX"));
+        assertEquals(0.0, registry.counter("betamis_league_joins_total").count());
+
+        useCase.join("league-1", "user-2", inv.code());
+        assertEquals(1.0, registry.counter("betamis_league_joins_total").count());
     }
 }
 

--- a/match-service/src/main/java/com/betamis/match/application/usecase/SyncMatchesUseCase.java
+++ b/match-service/src/main/java/com/betamis/match/application/usecase/SyncMatchesUseCase.java
@@ -9,6 +9,8 @@ import com.betamis.match.domain.port.in.SyncMatches;
 import com.betamis.match.domain.port.out.MatchDataProvider;
 import com.betamis.match.domain.port.out.MatchEventPublisher;
 import com.betamis.match.domain.port.out.MatchRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 
@@ -20,15 +22,18 @@ public class SyncMatchesUseCase implements SyncMatches {
     private final MatchDataProvider matchDataProvider;
     private final MatchRepository matchRepository;
     private final MatchEventPublisher eventPublisher;
+    private final Counter matchesSyncedCounter;
 
     public SyncMatchesUseCase(
             MatchDataProvider matchDataProvider,
             MatchRepository matchRepository,
-            MatchEventPublisher eventPublisher
+            MatchEventPublisher eventPublisher,
+            MeterRegistry registry
     ) {
         this.matchDataProvider = matchDataProvider;
         this.matchRepository = matchRepository;
         this.eventPublisher = eventPublisher;
+        this.matchesSyncedCounter = registry.counter("betamis_matches_synced_total");
     }
 
     @Override
@@ -54,6 +59,7 @@ public class SyncMatchesUseCase implements SyncMatches {
             // A match discovered for the first time is silently persisted regardless of status,
             // to avoid duplicate events if the service restarts mid-match.
             emitTransitionEvent(existing, newStatus, match);
+            matchesSyncedCounter.increment();
         }
     }
 

--- a/match-service/src/main/resources/application.properties
+++ b/match-service/src/main/resources/application.properties
@@ -40,6 +40,9 @@ mp.messaging.outgoing.match-finished.connector=smallrye-kafka
 mp.messaging.outgoing.match-finished.topic=match.finished
 mp.messaging.outgoing.match-finished.value.serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
 
+# ── Metrics (Prometheus) ──────────────────────────────────────────────────────
+quarkus.micrometer.export.prometheus.enabled=true
+
 # ── OpenTelemetry ─────────────────────────────────────────────────────────────
 quarkus.application.name=match-service
 quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}

--- a/match-service/src/test/java/com/betamis/match/application/usecase/SyncMatchesUseCaseTest.java
+++ b/match-service/src/test/java/com/betamis/match/application/usecase/SyncMatchesUseCaseTest.java
@@ -8,6 +8,7 @@ import com.betamis.match.domain.model.match.MatchStatus;
 import com.betamis.match.domain.port.out.MatchDataProvider;
 import com.betamis.match.domain.port.out.MatchEventPublisher;
 import com.betamis.match.domain.port.out.MatchRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,11 +33,13 @@ class SyncMatchesUseCaseTest {
     @Mock MatchRepository matchRepository;
     @Mock MatchEventPublisher eventPublisher;
 
+    SimpleMeterRegistry registry;
     SyncMatchesUseCase useCase;
 
     @BeforeEach
     void setUp() {
-        useCase = new SyncMatchesUseCase(matchDataProvider, matchRepository, eventPublisher);
+        registry = new SimpleMeterRegistry();
+        useCase = new SyncMatchesUseCase(matchDataProvider, matchRepository, eventPublisher, registry);
     }
 
     @Test
@@ -173,6 +176,25 @@ class SyncMatchesUseCaseTest {
 
         assertThrows(RuntimeException.class, () -> useCase.syncByCompetition("PL"));
         verify(matchRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("betamis_matches_synced_total increments once per match processed, 0 on empty list")
+    void shouldIncrementMatchesSyncedCounterPerMatch() {
+        assertEquals(0.0, registry.counter("betamis_matches_synced_total").count());
+
+        when(matchDataProvider.getMatchesByCompetition("PL")).thenReturn(List.of());
+        useCase.syncByCompetition("PL");
+        assertEquals(0.0, registry.counter("betamis_matches_synced_total").count());
+
+        when(matchDataProvider.getMatchesByCompetition("PL")).thenReturn(List.of(
+                externalMatch(11L, "SCHEDULED", 0, 0),
+                externalMatch(12L, "SCHEDULED", 0, 0),
+                externalMatch(13L, "SCHEDULED", 0, 0)
+        ));
+        when(matchRepository.findByExternalId(anyLong())).thenReturn(Optional.empty());
+        useCase.syncByCompetition("PL");
+        assertEquals(3.0, registry.counter("betamis_matches_synced_total").count());
     }
 
     // --- helpers ---

--- a/prediction-service/src/main/java/com/betamis/prediction/application/usecase/ClosePredictionUseCase.java
+++ b/prediction-service/src/main/java/com/betamis/prediction/application/usecase/ClosePredictionUseCase.java
@@ -6,6 +6,8 @@ import com.betamis.prediction.domain.model.prediction.PredictionStatus;
 import com.betamis.prediction.domain.port.in.ClosePrediction;
 import com.betamis.prediction.domain.port.out.EventPublisher;
 import com.betamis.prediction.domain.port.out.PredictionRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -16,11 +18,15 @@ public class ClosePredictionUseCase implements ClosePrediction {
 
     private final PredictionRepository predictionRepository;
     private final EventPublisher eventPublisher;
+    private final Counter predictionsClosedCounter;
 
     @Inject
-    public ClosePredictionUseCase(PredictionRepository predictionRepository, EventPublisher eventPublisher) {
+    public ClosePredictionUseCase(PredictionRepository predictionRepository,
+                                  EventPublisher eventPublisher,
+                                  MeterRegistry registry) {
         this.predictionRepository = predictionRepository;
         this.eventPublisher = eventPublisher;
+        this.predictionsClosedCounter = registry.counter("betamis_predictions_closed_total");
     }
 
     @Override
@@ -34,5 +40,6 @@ public class ClosePredictionUseCase implements ClosePrediction {
             predictionRepository.update(prediction);
         }
         eventPublisher.publish(PredictionClosed.of(matchId));
+        predictionsClosedCounter.increment();
     }
 }

--- a/prediction-service/src/main/java/com/betamis/prediction/application/usecase/SubmitPredictionUseCase.java
+++ b/prediction-service/src/main/java/com/betamis/prediction/application/usecase/SubmitPredictionUseCase.java
@@ -7,6 +7,8 @@ import com.betamis.prediction.domain.model.score.Score;
 import com.betamis.prediction.domain.port.in.SubmitPrediction;
 import com.betamis.prediction.domain.port.out.EventPublisher;
 import com.betamis.prediction.domain.port.out.PredictionRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -17,11 +19,15 @@ public class SubmitPredictionUseCase implements SubmitPrediction {
 
     private final PredictionRepository predictionRepository;
     private final EventPublisher eventPublisher;
+    private final Counter predictionsSubmittedCounter;
 
     @Inject
-    public SubmitPredictionUseCase(PredictionRepository predictionRepository, EventPublisher eventPublisher) {
+    public SubmitPredictionUseCase(PredictionRepository predictionRepository,
+                                   EventPublisher eventPublisher,
+                                   MeterRegistry registry) {
         this.predictionRepository = predictionRepository;
         this.eventPublisher = eventPublisher;
+        this.predictionsSubmittedCounter = registry.counter("betamis_predictions_submitted_total");
     }
 
     @Override
@@ -38,6 +44,7 @@ public class SubmitPredictionUseCase implements SubmitPrediction {
                 eventPublisher.publish(event);
             }
         });
+        predictionsSubmittedCounter.increment();
         return prediction.getId();
     }
 }

--- a/prediction-service/src/main/resources/application.properties
+++ b/prediction-service/src/main/resources/application.properties
@@ -53,6 +53,9 @@ mp.messaging.incoming.match-started.value.deserializer=io.confluent.kafka.serial
 mp.messaging.incoming.match-started.specific.avro.reader=true
 mp.messaging.incoming.match-started.schema.registry.url=${KAFKA_SCHEMA_REGISTRY_URL:http://localhost:8081}
 
+# ── Metrics (Prometheus) ──────────────────────────────────────────────────────
+quarkus.micrometer.export.prometheus.enabled=true
+
 # ── OpenTelemetry ─────────────────────────────────────────────────────────────
 quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}
 

--- a/prediction-service/src/test/java/com/betamis/prediction/application/usecase/ClosePredictionUseCaseTest.java
+++ b/prediction-service/src/test/java/com/betamis/prediction/application/usecase/ClosePredictionUseCaseTest.java
@@ -7,6 +7,7 @@ import com.betamis.prediction.domain.model.prediction.PredictionStatus;
 import com.betamis.prediction.domain.model.score.Score;
 import com.betamis.prediction.domain.port.out.EventPublisher;
 import com.betamis.prediction.domain.port.out.PredictionRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,11 +30,13 @@ class ClosePredictionUseCaseTest {
     @Mock
     EventPublisher eventPublisher;
 
+    SimpleMeterRegistry registry;
     ClosePredictionUseCase useCase;
 
     @BeforeEach
     void setUp() {
-        useCase = new ClosePredictionUseCase(repository, eventPublisher);
+        registry = new SimpleMeterRegistry();
+        useCase = new ClosePredictionUseCase(repository, eventPublisher, registry);
     }
 
     @Test
@@ -72,6 +75,20 @@ class ClosePredictionUseCaseTest {
 
         verify(repository, never()).update(any());
         verify(eventPublisher).publish(argThat((PredictionClosed e) -> "match-empty".equals(e.matchId())));
+    }
+
+    @Test
+    void counter_increments_once_per_close_call_regardless_of_prediction_state() {
+        assertEquals(0.0, registry.counter("betamis_predictions_closed_total").count());
+
+        when(repository.findByMatchId("match-1")).thenReturn(List.of());
+        useCase.close("match-1");
+        assertEquals(1.0, registry.counter("betamis_predictions_closed_total").count());
+
+        when(repository.findByMatchId("match-2")).thenReturn(
+                List.of(submittedPrediction("pred-1", "match-2", "user-1")));
+        useCase.close("match-2");
+        assertEquals(2.0, registry.counter("betamis_predictions_closed_total").count());
     }
 
     private Prediction submittedPrediction(String id, String matchId, String userId) {

--- a/prediction-service/src/test/java/com/betamis/prediction/application/usecase/SubmitPredictionUseCaseTest.java
+++ b/prediction-service/src/test/java/com/betamis/prediction/application/usecase/SubmitPredictionUseCaseTest.java
@@ -7,6 +7,7 @@ import com.betamis.prediction.domain.model.prediction.PredictionStatus;
 import com.betamis.prediction.domain.model.score.Score;
 import com.betamis.prediction.domain.port.out.EventPublisher;
 import com.betamis.prediction.domain.port.out.PredictionRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,13 +31,15 @@ class SubmitPredictionUseCaseTest {
     @Mock
     EventPublisher eventPublisher;
 
+    SimpleMeterRegistry registry;
     SubmitPredictionUseCase useCase;
 
     static final Instant FUTURE_KICK_OFF = Instant.now().plus(1, ChronoUnit.HOURS);
 
     @BeforeEach
     void setUp() {
-        useCase = new SubmitPredictionUseCase(repository, eventPublisher);
+        registry = new SimpleMeterRegistry();
+        useCase = new SubmitPredictionUseCase(repository, eventPublisher, registry);
     }
 
     @Test
@@ -69,5 +72,20 @@ class SubmitPredictionUseCaseTest {
             () -> useCase.execute("match1", "user1", new Score(2, 1), FUTURE_KICK_OFF));
 
         verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("betamis_predictions_submitted_total increments on success, not on duplicate rejection")
+    void shouldIncrementCounterOnlyOnSuccessfulSubmit() {
+        assertEquals(0.0, registry.counter("betamis_predictions_submitted_total").count());
+
+        when(repository.existsByUserIdAndMatchId("user1", "match1")).thenReturn(true);
+        assertThrows(PredictionAlreadySubmittedException.class,
+            () -> useCase.execute("match1", "user1", new Score(1, 0), FUTURE_KICK_OFF));
+        assertEquals(0.0, registry.counter("betamis_predictions_submitted_total").count());
+
+        when(repository.existsByUserIdAndMatchId("user2", "match1")).thenReturn(false);
+        useCase.execute("match1", "user2", new Score(1, 0), FUTURE_KICK_OFF);
+        assertEquals(1.0, registry.counter("betamis_predictions_submitted_total").count());
     }
 }

--- a/scoring-service/src/main/java/com/betamis/scoring/application/usecase/ScoreMatchUseCase.java
+++ b/scoring-service/src/main/java/com/betamis/scoring/application/usecase/ScoreMatchUseCase.java
@@ -10,12 +10,16 @@ import com.betamis.scoring.domain.port.out.RankingRepository;
 import com.betamis.scoring.domain.port.out.ScoringEventPublisher;
 import com.betamis.scoring.domain.port.out.ScoringResultRepository;
 import com.betamis.scoring.domain.port.out.StoredPredictionRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
 public class ScoreMatchUseCase implements ScoreMatch {
@@ -28,6 +32,8 @@ public class ScoreMatchUseCase implements ScoreMatch {
     private final RankingRepository rankingRepository;
     private final ScoringEventPublisher eventPublisher;
     private final LeagueMembershipRepository leagueMembershipRepository;
+    private final Counter scoresComputedCounter;
+    private final Timer scoringTimer;
 
     @Inject
     public ScoreMatchUseCase(
@@ -35,38 +41,47 @@ public class ScoreMatchUseCase implements ScoreMatch {
             ScoringResultRepository scoringResultRepository,
             RankingRepository rankingRepository,
             ScoringEventPublisher eventPublisher,
-            LeagueMembershipRepository leagueMembershipRepository) {
+            LeagueMembershipRepository leagueMembershipRepository,
+            MeterRegistry registry) {
         this.predictionRepository = predictionRepository;
         this.scoringResultRepository = scoringResultRepository;
         this.rankingRepository = rankingRepository;
         this.eventPublisher = eventPublisher;
         this.leagueMembershipRepository = leagueMembershipRepository;
+        this.scoresComputedCounter = registry.counter("betamis_scores_computed_total");
+        this.scoringTimer = registry.timer("betamis_scoring_duration_seconds");
     }
 
     @Override
     public void score(String matchId, FinalScore finalScore) {
-        List<StoredPrediction> predictions = predictionRepository.findByMatchId(matchId);
+        long start = System.nanoTime();
+        try {
+            List<StoredPrediction> predictions = predictionRepository.findByMatchId(matchId);
 
-        for (StoredPrediction prediction : predictions) {
-            if (scoringResultRepository.existsByPredictionId(prediction.predictionId())) {
-                Log.infof("Prediction %s already scored, skipping", prediction.predictionId());
-                continue;
+            for (StoredPrediction prediction : predictions) {
+                if (scoringResultRepository.existsByPredictionId(prediction.predictionId())) {
+                    Log.infof("Prediction %s already scored, skipping", prediction.predictionId());
+                    continue;
+                }
+
+                ScoringResult result = ScoringResult.calculate(prediction, finalScore);
+                scoringResultRepository.save(result);
+
+                // Update the global league plus every private league the user belongs to.
+                List<String> leagues = new ArrayList<>();
+                leagues.add(GLOBAL_LEAGUE);
+                leagues.addAll(leagueMembershipRepository.findLeagueIdsByUserId(result.userId()));
+
+                for (String leagueId : leagues) {
+                    UserRanking ranking = rankingRepository.addPoints(result.userId(), leagueId, result.points());
+                    eventPublisher.publishRankingUpdated(ranking);
+                }
+
+                eventPublisher.publishPointsCalculated(result);
+                scoresComputedCounter.increment();
             }
-
-            ScoringResult result = ScoringResult.calculate(prediction, finalScore);
-            scoringResultRepository.save(result);
-
-            // Update the global league plus every private league the user belongs to.
-            List<String> leagues = new ArrayList<>();
-            leagues.add(GLOBAL_LEAGUE);
-            leagues.addAll(leagueMembershipRepository.findLeagueIdsByUserId(result.userId()));
-
-            for (String leagueId : leagues) {
-                UserRanking ranking = rankingRepository.addPoints(result.userId(), leagueId, result.points());
-                eventPublisher.publishRankingUpdated(ranking);
-            }
-
-            eventPublisher.publishPointsCalculated(result);
+        } finally {
+            scoringTimer.record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
         }
     }
 }

--- a/scoring-service/src/test/java/com/betamis/scoring/application/usecase/ScoreMatchUseCaseMixedTest.java
+++ b/scoring-service/src/test/java/com/betamis/scoring/application/usecase/ScoreMatchUseCaseMixedTest.java
@@ -9,6 +9,7 @@ import com.betamis.scoring.domain.port.out.RankingRepository;
 import com.betamis.scoring.domain.port.out.ScoringEventPublisher;
 import com.betamis.scoring.domain.port.out.ScoringResultRepository;
 import com.betamis.scoring.domain.port.out.StoredPredictionRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,7 @@ class ScoreMatchUseCaseMixedTest {
 
     @BeforeEach
     void setUp() {
-        useCase = new ScoreMatchUseCase(predictionRepository, scoringResultRepository, rankingRepository, eventPublisher, leagueMembershipRepository);
+        useCase = new ScoreMatchUseCase(predictionRepository, scoringResultRepository, rankingRepository, eventPublisher, leagueMembershipRepository, new SimpleMeterRegistry());
     }
 
     @Test

--- a/scoring-service/src/test/java/com/betamis/scoring/application/usecase/ScoreMatchUseCaseTest.java
+++ b/scoring-service/src/test/java/com/betamis/scoring/application/usecase/ScoreMatchUseCaseTest.java
@@ -9,6 +9,7 @@ import com.betamis.scoring.domain.port.out.RankingRepository;
 import com.betamis.scoring.domain.port.out.ScoringEventPublisher;
 import com.betamis.scoring.domain.port.out.ScoringResultRepository;
 import com.betamis.scoring.domain.port.out.StoredPredictionRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,8 +19,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -34,11 +36,13 @@ class ScoreMatchUseCaseTest {
     @Mock ScoringEventPublisher eventPublisher;
     @Mock LeagueMembershipRepository leagueMembershipRepository;
 
+    SimpleMeterRegistry registry;
     ScoreMatchUseCase useCase;
 
     @BeforeEach
     void setUp() {
-        useCase = new ScoreMatchUseCase(predictionRepository, scoringResultRepository, rankingRepository, eventPublisher, leagueMembershipRepository);
+        registry = new SimpleMeterRegistry();
+        useCase = new ScoreMatchUseCase(predictionRepository, scoringResultRepository, rankingRepository, eventPublisher, leagueMembershipRepository, registry);
     }
 
     @Test
@@ -110,5 +114,29 @@ class ScoreMatchUseCaseTest {
         verify(rankingRepository, times(2)).addPoints(anyString(), anyString(), anyInt());
         verify(eventPublisher, times(2)).publishPointsCalculated(any());
         verify(eventPublisher, times(2)).publishRankingUpdated(any());
+    }
+
+    @Test
+    @DisplayName("betamis_scores_computed_total counts only new scores; betamis_scoring_duration_seconds records every call")
+    void shouldRecordMetricsCorrectly() {
+        StoredPrediction fresh = new StoredPrediction("pred-1", "match-1", "user-1", new FinalScore(2, 1));
+        StoredPrediction alreadyScored = new StoredPrediction("pred-2", "match-1", "user-2", new FinalScore(0, 0));
+        when(predictionRepository.findByMatchId("match-1")).thenReturn(List.of(fresh, alreadyScored));
+        when(scoringResultRepository.existsByPredictionId("pred-1")).thenReturn(false);
+        when(scoringResultRepository.existsByPredictionId("pred-2")).thenReturn(true);
+        when(rankingRepository.addPoints(anyString(), anyString(), anyInt()))
+                .thenReturn(new UserRanking("user-1", "global", 3, 1));
+
+        assertEquals(0.0, registry.counter("betamis_scores_computed_total").count());
+        assertEquals(0, registry.timer("betamis_scoring_duration_seconds").count());
+
+        useCase.score("match-1", new FinalScore(2, 1));
+
+        assertEquals(1.0, registry.counter("betamis_scores_computed_total").count(),
+                "only the non-skipped prediction should be counted");
+        assertEquals(1, registry.timer("betamis_scoring_duration_seconds").count(),
+                "timer records once per score() call");
+        assertTrue(registry.timer("betamis_scoring_duration_seconds").totalTime(TimeUnit.NANOSECONDS) > 0,
+                "recorded duration should be positive");
     }
 }

--- a/scoring-service/src/test/java/com/betamis/scoring/infrastructure/messaging/ScoringIntegrationTest.java
+++ b/scoring-service/src/test/java/com/betamis/scoring/infrastructure/messaging/ScoringIntegrationTest.java
@@ -14,6 +14,7 @@ import com.betamis.scoring.domain.port.out.RankingRepository;
 import com.betamis.scoring.domain.port.out.ScoringEventPublisher;
 import com.betamis.scoring.domain.port.out.ScoringResultRepository;
 import com.betamis.scoring.domain.port.out.StoredPredictionRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,7 @@ class ScoringIntegrationTest {
     @BeforeEach
     void setUp() {
         StorePredictionUseCase storePrediction = new StorePredictionUseCase(predictionRepository);
-        ScoreMatchUseCase scoreMatch = new ScoreMatchUseCase(predictionRepository, scoringResultRepository, rankingRepository, eventPublisher, leagueMembershipRepository);
+        ScoreMatchUseCase scoreMatch = new ScoreMatchUseCase(predictionRepository, scoringResultRepository, rankingRepository, eventPublisher, leagueMembershipRepository, new SimpleMeterRegistry());
         predictionConsumer = new KafkaPredictionConsumer(storePrediction);
         matchConsumer = new KafkaMatchFinishedConsumer(scoreMatch);
     }


### PR DESCRIPTION
Closes #16

## Summary

- **Custom metrics** injected via `MeterRegistry` (constructor injection) into all 6 business use cases: `betamis_leagues_created_total`, `betamis_league_joins_total`, `betamis_matches_synced_total`, `betamis_predictions_submitted_total`, `betamis_predictions_closed_total`, `betamis_scores_computed_total` + `betamis_scoring_duration_seconds` timer on `ScoreMatchUseCase`
- **Prometheus enabled** explicitly in `application.properties` for league, match and prediction services (scoring already had it)
- **`name: http`** added to the Service port in all 4 service charts — required for ServiceMonitor endpoint selection
- **`helm/kube-prometheus-stack`** — values for kube-prometheus-stack with per-env resource sizing; Grafana and Alertmanager disabled (BetAmis already runs Grafana; wire alertmanager receiver when needed); all-namespace ServiceMonitor/Rule selectors
- **`helm/prometheus`** — 4 ServiceMonitors (one per service, scraping `/q/metrics` every 30s) + `PrometheusRule` with 3 alerts:
  - `BetamisServiceDown` — `up == 0` for 2 min
  - `BetamisKafkaConsumerLagHigh` — scoring-service consumer lag > 1000 for 5 min
  - `BetamisHttpErrorRateHigh` — 5xx rate > 5% for 5 min
- **helmfile** — `prometheus-community` repo added; `kube-prometheus-stack` (monitoring ns) and `prometheus` (app ns) releases added

## Test plan

- [ ] `helmfile -e dev sync` deploys without errors
- [ ] `kubectl -n betamis-dev get servicemonitor` shows 4 monitors
- [ ] Prometheus UI → Status → Targets shows all 4 service scrape targets as UP
- [ ] After creating a league, `betamis_leagues_created_total` appears in Prometheus
- [ ] After scoring a match, `betamis_scores_computed_total` and `betamis_scoring_duration_seconds` appear
- [ ] `kubectl delete pod <scoring-service-pod>` → `BetamisServiceDown` fires within 3 min
- [ ] Simulate lag on scoring-service topics → `BetamisKafkaConsumerLagHigh` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)