### PR TITLE
feat(#56): GET /predictions?matchId={id} — fetch user prediction

### DIFF
--- a/pacts/frontend-prediction-service.json
+++ b/pacts/frontend-prediction-service.json
@@ -1,0 +1,141 @@
+{
+  "consumer": {
+    "name": "frontend"
+  },
+  "interactions": [
+    {
+      "description": "a request for the current user's prediction for a match",
+      "pending": false,
+      "providerStates": [
+        {
+          "name": "user user-pact has a prediction for match match-pact-1"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/predictions",
+        "query": {
+          "matchId": ["match-pact-1"]
+        }
+      },
+      "response": {
+        "body": {
+          "awayTeamScore": 1,
+          "homeTeamScore": 2,
+          "id": "pred-uuid-1",
+          "matchId": "match-pact-1",
+          "status": "SUBMITTED",
+          "submittedAt": "2026-07-09T14:30:00Z",
+          "userId": "user-pact"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.awayTeamScore": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.homeTeamScore": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.matchId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.submittedAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.userId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "header": {
+            "Content-Type": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "application/json.*"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      },
+      "type": "Synchronous/HTTP"
+    },
+    {
+      "description": "a request for the current user's prediction when none exists",
+      "pending": false,
+      "providerStates": [
+        {
+          "name": "user user-pact has no prediction for match match-pact-none"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/predictions",
+        "query": {
+          "matchId": ["match-pact-none"]
+        }
+      },
+      "response": {
+        "status": 404
+      },
+      "type": "Synchronous/HTTP"
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.6.16"
+    },
+    "pactSpecification": {
+      "version": "4.0"
+    }
+  },
+  "provider": {
+    "name": "prediction-service"
+  }
+}

--- a/prediction-service/src/main/java/com/betamis/prediction/application/usecase/GetPredictionUseCase.java
+++ b/prediction-service/src/main/java/com/betamis/prediction/application/usecase/GetPredictionUseCase.java
@@ -1,0 +1,24 @@
+package com.betamis.prediction.application.usecase;
+
+import com.betamis.prediction.domain.exception.PredictionNotFoundException;
+import com.betamis.prediction.domain.model.prediction.Prediction;
+import com.betamis.prediction.domain.port.in.GetPrediction;
+import com.betamis.prediction.domain.port.out.PredictionRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class GetPredictionUseCase implements GetPrediction {
+
+    private final PredictionRepository predictionRepository;
+
+    public GetPredictionUseCase(PredictionRepository predictionRepository) {
+        this.predictionRepository = predictionRepository;
+    }
+
+    @Override
+    public Prediction execute(String matchId, String userId) {
+        return predictionRepository.findByUserIdAndMatchId(userId, matchId)
+                .orElseThrow(() -> new PredictionNotFoundException(
+                        "No prediction found for match %s".formatted(matchId)));
+    }
+}

--- a/prediction-service/src/main/java/com/betamis/prediction/domain/port/in/GetPrediction.java
+++ b/prediction-service/src/main/java/com/betamis/prediction/domain/port/in/GetPrediction.java
@@ -1,0 +1,7 @@
+package com.betamis.prediction.domain.port.in;
+
+import com.betamis.prediction.domain.model.prediction.Prediction;
+
+public interface GetPrediction {
+    Prediction execute(String matchId, String userId);
+}

--- a/prediction-service/src/main/java/com/betamis/prediction/domain/port/out/PredictionRepository.java
+++ b/prediction-service/src/main/java/com/betamis/prediction/domain/port/out/PredictionRepository.java
@@ -3,9 +3,11 @@ package com.betamis.prediction.domain.port.out;
 import com.betamis.prediction.domain.model.prediction.Prediction;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PredictionRepository {
     Prediction findById(String id);
+    Optional<Prediction> findByUserIdAndMatchId(String userId, String matchId);
     List<Prediction> findByMatchId(String matchId);
     void save(Prediction prediction);
     void update(Prediction prediction);

--- a/prediction-service/src/main/java/com/betamis/prediction/infrastructure/persistence/PredictionRepositoryAdapter.java
+++ b/prediction-service/src/main/java/com/betamis/prediction/infrastructure/persistence/PredictionRepositoryAdapter.java
@@ -9,6 +9,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @ApplicationScoped
 public class PredictionRepositoryAdapter implements PredictionRepository {
@@ -34,6 +35,14 @@ public class PredictionRepositoryAdapter implements PredictionRepository {
                 .firstResultOptional()
                 .map(this::toDomain)
                 .orElse(null);
+    }
+
+    @Override
+    @Transactional
+    public Optional<Prediction> findByUserIdAndMatchId(String userId, String matchId) {
+        return PredictionEntity.<PredictionEntity>find("userId = ?1 and matchId = ?2", userId, matchId)
+                .firstResultOptional()
+                .map(this::toDomain);
     }
 
     @Override

--- a/prediction-service/src/main/java/com/betamis/prediction/interfaces/rest/PredictionResource.java
+++ b/prediction-service/src/main/java/com/betamis/prediction/interfaces/rest/PredictionResource.java
@@ -2,6 +2,7 @@ package com.betamis.prediction.interfaces.rest;
 
 import com.betamis.prediction.domain.model.prediction.Prediction;
 import com.betamis.prediction.domain.model.score.Score;
+import com.betamis.prediction.domain.port.in.GetPrediction;
 import com.betamis.prediction.domain.port.in.SubmitPrediction;
 import com.betamis.prediction.domain.port.in.UpdatePrediction;
 import com.betamis.prediction.interfaces.rest.dto.PredictionResponse;
@@ -12,11 +13,13 @@ import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -32,14 +35,28 @@ public class PredictionResource {
 
     private final SubmitPrediction submitPrediction;
     private final UpdatePrediction updatePrediction;
+    private final GetPrediction getPrediction;
     private final SecurityIdentity identity;
 
     @Inject
     public PredictionResource(SubmitPrediction submitPrediction, UpdatePrediction updatePrediction,
-                               SecurityIdentity identity) {
+                               GetPrediction getPrediction, SecurityIdentity identity) {
         this.submitPrediction = submitPrediction;
         this.updatePrediction = updatePrediction;
+        this.getPrediction = getPrediction;
         this.identity = identity;
+    }
+
+    @GET
+    @RolesAllowed(USER_ROLE)
+    public Response getPrediction(@QueryParam("matchId") String matchId) {
+        if (matchId == null || matchId.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(new DomainExceptionMapper.ErrorResponse("matchId must not be blank"))
+                    .build();
+        }
+        String userId = identity.getPrincipal().getName();
+        return Response.ok(PredictionResponse.from(getPrediction.execute(matchId, userId))).build();
     }
 
     @POST

--- a/prediction-service/src/main/java/com/betamis/prediction/interfaces/rest/dto/PredictionResponse.java
+++ b/prediction-service/src/main/java/com/betamis/prediction/interfaces/rest/dto/PredictionResponse.java
@@ -2,13 +2,16 @@ package com.betamis.prediction.interfaces.rest.dto;
 
 import com.betamis.prediction.domain.model.prediction.Prediction;
 
+import java.time.Instant;
+
 public record PredictionResponse(
         String id,
         String matchId,
         String userId,
-        int homeScore,
-        int awayScore,
-        String status
+        int homeTeamScore,
+        int awayTeamScore,
+        String status,
+        Instant submittedAt
 ) {
     public static PredictionResponse from(Prediction prediction) {
         return new PredictionResponse(
@@ -17,7 +20,8 @@ public record PredictionResponse(
                 prediction.getUserId(),
                 prediction.getScore().homeTeamScore(),
                 prediction.getScore().awayTeamScore(),
-                prediction.getStatus().name()
+                prediction.getStatus().name(),
+                prediction.getSubmittedAt()
         );
     }
 }

--- a/prediction-service/src/test/java/com/betamis/prediction/contract/GetPredictionPactProviderTest.java
+++ b/prediction-service/src/test/java/com/betamis/prediction/contract/GetPredictionPactProviderTest.java
@@ -1,0 +1,70 @@
+package com.betamis.prediction.contract;
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Consumer;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import com.betamis.prediction.domain.model.score.Score;
+import com.betamis.prediction.domain.port.in.SubmitPrediction;
+import com.betamis.prediction.domain.port.out.PredictionRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.inject.Inject;
+import java.time.Instant;
+
+/**
+ * Provider-side Pact contract test for GET /predictions (HTTP).
+ *
+ * <p>Reads {@code ../pacts/frontend-prediction-service.json} and verifies that
+ * prediction-service satisfies the frontend consumer's expectations.
+ * {@code @TestSecurity} makes the running test server accept all requests as
+ * {@code user-pact} with the {@code betamis-user} role — matching the user
+ * identity used in the pact state definitions.
+ */
+@QuarkusTest
+@TestSecurity(user = "user-pact", roles = "betamis-user")
+@Provider("prediction-service")
+@Consumer("frontend")
+@PactFolder("../pacts")
+class GetPredictionPactProviderTest {
+
+    @Inject
+    SubmitPrediction submitPrediction;
+
+    @Inject
+    PredictionRepository predictionRepository;
+
+    @BeforeEach
+    void setUp(PactVerificationContext context) {
+        if (context != null) {
+            context.setTarget(new HttpTestTarget("localhost", RestAssured.port));
+        }
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void verifyPact(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @State("user user-pact has a prediction for match match-pact-1")
+    void setupUserPrediction() {
+        if (predictionRepository.findByUserIdAndMatchId("user-pact", "match-pact-1").isEmpty()) {
+            submitPrediction.execute("match-pact-1", "user-pact",
+                    new Score(2, 1), Instant.parse("2099-06-15T15:00:00Z"));
+        }
+    }
+
+    @State("user user-pact has no prediction for match match-pact-none")
+    void noUserPrediction() {
+        // no data to insert — user has made no prediction for this match
+    }
+}

--- a/prediction-service/src/test/java/com/betamis/prediction/contract/PredictionSubmittedPactProviderTest.java
+++ b/prediction-service/src/test/java/com/betamis/prediction/contract/PredictionSubmittedPactProviderTest.java
@@ -4,6 +4,7 @@ import au.com.dius.pact.provider.PactVerifyProvider;
 import au.com.dius.pact.provider.junit5.MessageTestTarget;
 import au.com.dius.pact.provider.junit5.PactVerificationContext;
 import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Consumer;
 import au.com.dius.pact.provider.junitsupport.Provider;
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,6 +27,7 @@ import java.util.UUID;
  * consumer.  The build fails if the provider breaks the contract.
  */
 @Provider("prediction-service")
+@Consumer("scoring-service")
 @PactFolder("../pacts")
 class PredictionSubmittedPactProviderTest {
 

--- a/prediction-service/src/test/java/com/betamis/prediction/interfaces/rest/PredictionResourceIT.java
+++ b/prediction-service/src/test/java/com/betamis/prediction/interfaces/rest/PredictionResourceIT.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 /**
- * REST integration tests for POST /predictions and PATCH /predictions/{id}.
+ * REST integration tests for GET/POST /predictions and PATCH /predictions/{id}.
  * Uses PostgreSQL DevServices via Quarkus and @TestSecurity to bypass JWT validation.
  */
 @QuarkusTest
@@ -130,8 +130,8 @@ class PredictionResourceIT {
                 .patch("/predictions/" + predictionId)
         .then()
                 .statusCode(200)
-                .body("homeScore", is(3))
-                .body("awayScore", is(2))
+                .body("homeTeamScore", is(3))
+                .body("awayTeamScore", is(2))
                 .body("status", is("SUBMITTED"))
                 .body("id", is(predictionId));
     }
@@ -224,6 +224,62 @@ class PredictionResourceIT {
                         """)
         .when()
                 .patch("/predictions/some-id")
+        .then()
+                .statusCode(400);
+    }
+
+    // ── GET /predictions?matchId={matchId} ────────────────────────────────────
+
+    @Test
+    @TestSecurity(user = "user-get-ok", roles = "betamis-user")
+    void getPrediction_returns200WithPrediction() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"matchId":"match-get-1","homeScore":2,"awayScore":1,"kickOffTime":"%s"}
+                        """.formatted(FUTURE_KICK_OFF))
+                .post("/predictions")
+                .then().statusCode(201);
+
+        given()
+        .when()
+                .get("/predictions?matchId=match-get-1")
+        .then()
+                .statusCode(200)
+                .body("matchId", is("match-get-1"))
+                .body("userId", is("user-get-ok"))
+                .body("homeTeamScore", is(2))
+                .body("awayTeamScore", is(1))
+                .body("status", is("SUBMITTED"))
+                .body("id", notNullValue())
+                .body("submittedAt", notNullValue());
+    }
+
+    @Test
+    @TestSecurity(user = "user-get-nf", roles = "betamis-user")
+    void getPrediction_notFound_returns404() {
+        given()
+        .when()
+                .get("/predictions?matchId=match-get-no-prediction")
+        .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void getPrediction_withoutAuth_returns401() {
+        given()
+        .when()
+                .get("/predictions?matchId=match-get-unauth")
+        .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "user-get-nmi", roles = "betamis-user")
+    void getPrediction_missingMatchId_returns400() {
+        given()
+        .when()
+                .get("/predictions")
         .then()
                 .statusCode(400);
     }


### PR DESCRIPTION
## Summary

- Adds `GET /predictions?matchId={matchId}` returning the authenticated user's prediction for a match (404 if none exists)
- Updates `PredictionResponse` to canonical field names (`homeTeamScore`, `awayTeamScore`, `submittedAt`) matching the frontend contract spec
- Publishes `pacts/frontend-prediction-service.json` (Synchronous/HTTP Pact) and a provider verification test (`GetPredictionPactProviderTest`)

## Test plan

- [ ] `PredictionResourceIT` — GET 200 (returns correct prediction), 404 (no prediction), 401 (unauthenticated), 400 (missing matchId)
- [ ] `GetPredictionPactProviderTest` — verifies the HTTP Pact contract against the running Quarkus test server
- [ ] Existing PATCH IT assertions updated for renamed response fields

Closes #56